### PR TITLE
Fix omnispawn particle and sound effect issues.

### DIFF
--- a/Blue Burst Patch Project/Blue Burst Patch Project.vcxproj
+++ b/Blue Burst Patch Project/Blue Burst Patch Project.vcxproj
@@ -57,7 +57,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>PATCH_SKIP_INTRO_CREDITS;PATCH_LARGE_ASSETS;PATCH_ENEMY_CONSTRUCTOR_LISTS;PATCH_IME;PATCH_SLOW_GIBBLES_FIX;PATCH_CUSTOMIZE_MENU;PATCH_FASTWARP;PATCH_OMNISPAWN;PATCH_INITLISTS;PATCH_MAP_OBJECT_CONSTRUCTOR_LISTS;PATCH_HOOKS;WIN32;_DEBUG;BLUEBURSTPATCHPROJECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;BLUEBURSTPATCHPROJECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>

--- a/Blue Burst Patch Project/Blue Burst Patch Project.vcxproj
+++ b/Blue Burst Patch Project/Blue Burst Patch Project.vcxproj
@@ -57,7 +57,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;BLUEBURSTPATCHPROJECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PATCH_SKIP_INTRO_CREDITS;PATCH_LARGE_ASSETS;PATCH_ENEMY_CONSTRUCTOR_LISTS;PATCH_IME;PATCH_SLOW_GIBBLES_FIX;PATCH_CUSTOMIZE_MENU;PATCH_FASTWARP;PATCH_OMNISPAWN;PATCH_INITLISTS;PATCH_MAP_OBJECT_CONSTRUCTOR_LISTS;PATCH_HOOKS;WIN32;_DEBUG;BLUEBURSTPATCHPROJECT_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -148,6 +148,7 @@
     <ClCompile Include="keyboard.cpp" />
     <ClCompile Include="large_assets.cpp" />
     <ClCompile Include="map.cpp" />
+    <ClCompile Include="map_object.cpp" />
     <ClCompile Include="mathutil.cpp" />
     <ClCompile Include="newenemy.cpp" />
     <ClCompile Include="newgfx\animation.cpp" />
@@ -158,6 +159,8 @@
     <ClCompile Include="object_extension.cpp" />
     <ClCompile Include="object_wrapper.cpp" />
     <ClCompile Include="omnispawn.cpp" />
+    <ClCompile Include="omnispawn_particles.cpp" />
+    <ClCompile Include="omnispawn_sound_effects.cpp" />
     <ClCompile Include="palette.cpp" />
     <ClCompile Include="psobb.cpp" />
     <ClCompile Include="psobb_functions.cpp" />

--- a/Blue Burst Patch Project/Blue Burst Patch Project.vcxproj.filters
+++ b/Blue Burst Patch Project/Blue Burst Patch Project.vcxproj.filters
@@ -27,9 +27,6 @@
     <ClInclude Include="framework.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="pch.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="globals.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -117,21 +114,18 @@
     <ClInclude Include="psobb_functions.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClCompile Include="hooking.h">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="keyboard.h">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="entity.h">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+    <ClInclude Include="entity.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="hooking.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="keyboard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="psobb.cpp">
@@ -246,6 +240,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="entity.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="omnispawn_particles.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="map_object.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="omnispawn_sound_effects.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Blue Burst Patch Project/common.cpp
+++ b/Blue Burst Patch Project/common.cpp
@@ -81,5 +81,16 @@ std::string joinPath(const std::initializer_list<std::string>& parts)
 
 std::wstring ToWideString(const std::string& narrow)
 {
+#ifdef WIN32
+    // codecvt is deprecated
+    int numWideChars = MultiByteToWideChar(CP_UTF8, 0, narrow.c_str(), -1, NULL, 0);
+    if (0 == numWideChars)
+        return std::wstring(L"");
+
+    wchar_t *wideStr = new wchar_t[numWideChars + 1];
+    MultiByteToWideChar(CP_UTF8, 0, narrow.c_str(), -1, wideStr, numWideChars);
+    return std::wstring(wideStr);
+#else
     return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(narrow);
+#endif
 }

--- a/Blue Burst Patch Project/helpers.h
+++ b/Blue Burst Patch Project/helpers.h
@@ -11,6 +11,10 @@
 #include <vector>
 #include <windows.h>
 
+#ifdef _WIN32
+#undef min
+#endif
+
 typedef uint8_t byte;
 
 int gcd(int a, int b);

--- a/Blue Burst Patch Project/omnispawn.cpp
+++ b/Blue Burst Patch Project/omnispawn.cpp
@@ -54,7 +54,8 @@ namespace Omnispawn
         NewBPIndex::Delsaber,
         NewBPIndex::Dimenian,
         NewBPIndex::LaDimenian,
-        NewBPIndex::SoDimenian
+        NewBPIndex::SoDimenian,
+        NewBPIndex::GrassAssassin,
     };
 
     struct BPIndexAll
@@ -1412,49 +1413,49 @@ namespace Omnispawn
     NpcType newEnemies[] =
     {
         NpcType::Hildebear,
-        NpcType::Rag_Rappy_Sand_Rappy,
+        NpcType::RagRappy_SandRappy,
         NpcType::Monest,
-        NpcType::Savage_Wolf,
+        NpcType::SavageWolf,
         NpcType::Booma,
-        NpcType::Grass_Assassin,
-        NpcType::Poison_Lily_Del_Lily,
-        NpcType::Nano_Dragon,
-        NpcType::Evil_Shark,
-        NpcType::Pofuilly_Slime,
-        NpcType::Pan_Arms,
-        NpcType::Gillchic,
+        NpcType::GrassAssassin,
+        NpcType::PoisonLily_DelLily,
+        NpcType::NanoDragon,
+        NpcType::EvilShark,
+        NpcType::PofuillySlime,
+        NpcType::PanArms,
+        NpcType::Gillchic_Dubchic,
         NpcType::Garanz,
-        NpcType::Sinow_Beat,
+        NpcType::SinowBeat,
         NpcType::Canadine,
         NpcType::Canane,
-        NpcType::Dubchic_Switch,
+        NpcType::Dubwitch,
         NpcType::Delsaber,
-        NpcType::Chaos_Sorcerer,
-        NpcType::Dark_Gunner,
-        NpcType::Death_Gunner,
-        NpcType::Chaos_Bringer,
-        NpcType::Darth_Belra,
+        NpcType::ChaosSorcerer,
+        NpcType::DarkGunner,
+        NpcType::DeathGunner,
+        NpcType::ChaosBringer,
+        NpcType::DarkBelra,
         NpcType::Dimenian,
         NpcType::Bulclaw,
         NpcType::Claw,
-        NpcType::Sinow_Berill,
-        NpcType::Merillias,
+        NpcType::SinowBerill,
+        NpcType::Merillia,
         NpcType::Mericarol,
-        NpcType::Ul_Gibbon,
+        NpcType::UlGibbon,
         NpcType::Gibbles,
         NpcType::Gee,
-        NpcType::Gi_Gue,
+        NpcType::GiGue,
         NpcType::Deldepth,
         NpcType::Delbiter,
-        NpcType::Dolmdarl,
+        NpcType::Dolmolm,
         NpcType::Morfos,
         NpcType::Recobox,
-        NpcType::Epsilon_Sinow_Zoa,
-        NpcType::Ill_Gill,
+        NpcType::Epsilon_SinowZoa,
+        NpcType::IllGill,
         NpcType::Astark,
-        NpcType::Satellite_Lizard,
-        NpcType::Merissa_A,
-        NpcType::Girt,
+        NpcType::SatelliteLizard,
+        NpcType::MerissaA,
+        NpcType::Girtablulu,
         NpcType::Zu,
         NpcType::Boota,
         NpcType::Dorphon,
@@ -1513,7 +1514,7 @@ namespace Omnispawn
         }
 
         // Ensure Epsilon is chosen over Sinow Zoa
-        enemyConstructors[NpcType::Epsilon_Sinow_Zoa] = reinterpret_cast<Enemy::TaggedEnemyConstructor*>(0x009fae90);
+        enemyConstructors[NpcType::Epsilon_SinowZoa] = reinterpret_cast<Enemy::TaggedEnemyConstructor*>(0x009fae90);
 
         // Add new enemies to all maps
         for (size_t i = 0; i <= (size_t) MapType::MAX_INDEX; i++)
@@ -1527,7 +1528,7 @@ namespace Omnispawn
 
                 for (const Enemy::TaggedEnemyConstructor& oldEnemy : mapEnemyList)
                 {
-                    if (oldEnemy.enemyType == newEnemy)
+                    if (oldEnemy.enemyType == (uint16_t)newEnemy)
                     {
                         found = true;
                         break;
@@ -1757,42 +1758,6 @@ namespace Omnispawn
         *(uint8_t*)0x00782496 = 0xeb;
     }
 
-    typedef uint32_t (__cdecl *LoadMapSoundDataFunction)(uint32_t);
-    LoadMapSoundDataFunction LoadMapSoundData = reinterpret_cast<LoadMapSoundDataFunction>(0x00828d40);
-
-    /// Loads all map-specific .pac files
-    void __cdecl LoadSoundDataAllMaps()
-    {
-        for (uint32_t i = 0; i <= (uint32_t) MapType::MAX_INDEX; i++)
-        {
-            if (LoadMapSoundData(i) == 0)
-            {
-                return;
-            }
-        }
-
-        return;
-    }
-
-    void PatchSoundEffects()
-    {
-        // This is an initlist that loads assets that should stay loaded 
-        // for the entire lifetime of the program
-        InitList& lst = InitList::GetInitList(0x009ff6e0, 0x009ff7c0);
-        // No uninit function because at that point the game is exiting anyway
-        lst.AddFunctionPair(InitList::FunctionPair(LoadSoundDataAllMaps, nullptr));
-        lst.AddListReferenceAddress({0x007a666d + 1, 0x007a63a7 + 1});
-        lst.AddSizeReferenceAddress({0x007a63a2 + 1, 0x007a6668 + 1});
-
-        // Stub out load_map_sound_data_:00815584
-        // Because verything should already be loaded
-        StubOutFunction(0x00815584, 0x0081558f);
-
-        // Stub out unload_map_sound_data:00828c38
-        // Because we wan't to keep everything loaded permanently
-        StubOutFunction(0x00828c38, 0x00828d24);
-    }
-
     bool patchApplied = false;
     void ApplyOmnispawnPatch()
     {
@@ -1805,8 +1770,8 @@ namespace Omnispawn
         PatchBPGetters();
         UnhardcodeBattleParamIndices();
         PatchRagolAssetLoading();
-        PatchSoundEffects();
-
+        PatchOmnispawnSoundEffects();
+        PatchOmnispawnParticles();
         patchApplied = true;
     }
 };

--- a/Blue Burst Patch Project/omnispawn.h
+++ b/Blue Burst Patch Project/omnispawn.h
@@ -136,5 +136,7 @@ namespace Omnispawn
         EP4_END_INDEX = Girtablulu
     };
 
+    void PatchOmnispawnParticles();
+    void PatchOmnispawnSoundEffects();
     void ApplyOmnispawnPatch();
 };

--- a/Blue Burst Patch Project/omnispawn_particles.cpp
+++ b/Blue Burst Patch Project/omnispawn_particles.cpp
@@ -1,0 +1,336 @@
+#include "helpers.h"
+#include "omnispawn.h"
+#include <mathutil.h>
+#include "map.h"
+
+// TODO: Cleanup this file.
+
+namespace Omnispawn
+{
+    using Map::MapType;
+
+#define MAP_PARTICLEENTRY_SIZE  (0x2600)
+// Helper macros to swap out the client's loaded map particle data.
+#define GET_MAP_PARTICLEENTRY(a) ((a) = *(byte **)0xa72ccc)
+#define SET_MAP_PARTICLEENTRY(a) (*(byte **)0xa72ccc = (a))
+#define RESTORE_MAP_PARTICLEENTRY(a)  (SET_MAP_PARTICLEENTRY((a)))
+#define REPLACE_MAP_PARTICLEENTRY(a, b)                   \
+   do {                                                   \
+       GET_MAP_PARTICLEENTRY((a));                        \
+       if ((b))                                           \
+       {                                                  \
+           SET_MAP_PARTICLEENTRY((b));                    \
+       }                                                  \
+   } while (0)                                             
+
+
+    // Index is map, element is pointer to particle data.
+    // TODO: Structure for particles to make this nicer.
+    static byte *omniMapParticleData[(size_t)MapType::MAX_INDEX + 1];
+
+    // Load all particle entry files once.
+    static void LoadAllMapParticleEntryFiles()
+    {
+        static int loaded = 0;
+        if (loaded)
+            return;
+
+        char fn[128];
+
+        // For each map, load particleentry file and store it into the global
+        for (int iMap = 0; iMap < (size_t)MapType::MAX_INDEX; ++iMap)
+        {
+            // The game actually uses new here but it doesn't matter, we keep
+            // this memory allocated for the lifetime of the client.
+            byte *data = (byte *)malloc(MAP_PARTICLEENTRY_SIZE);
+
+            sprintf_s(&fn[0], sizeof(fn), "particleentrya%-02d.dat", iMap);
+
+            uint32_t(__cdecl * pf_load)(char *, byte *) = (uint32_t(__cdecl *)(char *, byte *))0x5b9910;
+            (*pf_load)(&fn[0], data);
+
+            omniMapParticleData[iMap] = data;
+        }
+
+        loaded = 1;
+    }
+
+    // Wraps the loading of particleentry.dat for particles 0-511 inclusive.
+    // On first call, loads all of the map specific particles.
+    static uint32_t __cdecl WrapLoadParticleEntry(void)
+    {
+        // First time here will load all map particles.
+        LoadAllMapParticleEntryFiles();
+
+        // Original function being wrapped.
+        uint32_t(__cdecl *pfLoadOneMapParticleEntry)(void) = (uint32_t(__cdecl *)(void))0x50d9a0;
+        uint32_t ret = (*pfLoadOneMapParticleEntry)();
+
+        // Copy whatever the game loaded into our data so that particles are reloaded when entering maps.
+        uint32_t currentMap = *(uint32_t *)0xaafc9c;
+
+        byte *mapParticleEntryData = *(byte **)0xa72ccc;
+        if (mapParticleEntryData)
+        {
+            memcpy_s(omniMapParticleData[currentMap], MAP_PARTICLEENTRY_SIZE,
+                mapParticleEntryData, MAP_PARTICLEENTRY_SIZE);
+        }
+
+        return ret;
+    }
+
+    byte *__cdecl FUN_0050b510_WithMap(Vec3f *pos, int particleId, int mapId)
+    {
+        byte *save;
+
+        REPLACE_MAP_PARTICLEENTRY(save, omniMapParticleData[mapId]);
+
+        byte *(__cdecl * pf)(Vec3f *, int) = (byte * (__cdecl *)(Vec3f *, int))0x50b510;
+        byte *ret = (*pf)(pos, particleId);
+
+        RESTORE_MAP_PARTICLEENTRY(save);
+
+        return ret;
+    }
+
+    byte *__cdecl FUN_00509dc4_WithMap(Vec3f *pos, Vec3f *pos2, int particleId, uint16_t flags, int mapId)
+    {
+        byte *save;
+
+        REPLACE_MAP_PARTICLEENTRY(save, omniMapParticleData[mapId]);
+
+        byte *(__cdecl * pf)(Vec3f *, Vec3f *, int, uint16_t) =
+            (byte * (__cdecl *)(Vec3f *, Vec3f *, int, uint16_t))0x509dc4;
+        byte *ret = (*pf)(pos, pos2, particleId, flags);
+
+        RESTORE_MAP_PARTICLEENTRY(save);
+
+        return ret;
+    }
+
+    byte *__cdecl FUN_00509590_WithMap(Vec3f *pos, int particleId, int mapId)
+    {
+        byte *save;
+
+        REPLACE_MAP_PARTICLEENTRY(save, omniMapParticleData[mapId]);
+
+        byte *(__cdecl * pf)(Vec3f *, int) =(byte * (__cdecl *)(Vec3f *, int))0x509590;
+        byte *ret = (*pf)(pos, particleId);
+
+        RESTORE_MAP_PARTICLEENTRY(save);
+
+        return ret;
+    }
+
+    byte *__cdecl FUN_0050a664_WithMap(Vec3f *pos, Vec3f *pos2, int particleId, int param4, uint16_t flags, int mapId)
+    {
+        byte *save;
+
+        REPLACE_MAP_PARTICLEENTRY(save, omniMapParticleData[mapId]);
+
+        byte *(__cdecl * pf)(Vec3f *, Vec3f *, int, int, uint16_t) =
+            (byte * (__cdecl *)(Vec3f *, Vec3f *, int, int, uint16_t))0x50a664;
+        byte *ret = (*pf)(pos, pos2, particleId, param4, flags);
+
+        RESTORE_MAP_PARTICLEENTRY(save);
+
+        return ret;
+    }
+
+    byte *__cdecl FUN_0050bab4_WithMap(Vec3f *pos, Vec3f *pos2, int particleId, int mapId)
+    {
+        byte *save;
+
+        REPLACE_MAP_PARTICLEENTRY(save, omniMapParticleData[mapId]);
+
+        byte *(__cdecl * pf)(Vec3f *, Vec3f *, int) = (byte * (__cdecl *)(Vec3f *, Vec3f *, int))0x50bab4;
+        byte *ret = (*pf)(pos, pos2, particleId);
+
+        RESTORE_MAP_PARTICLEENTRY(save);
+
+        return ret;
+    }
+
+    byte *__cdecl FUN_00509b24_WithMap(Vec3f *pos, Vec3f *pos2, int particleId, int mapId)
+    {
+        byte *save;
+
+        REPLACE_MAP_PARTICLEENTRY(save, omniMapParticleData[mapId]);
+
+        byte *(__cdecl * pf)(Vec3f *, Vec3f *, int) = (byte * (__cdecl *)(Vec3f *, Vec3f *, int))0x509b24;
+        byte *ret = (*pf)(pos, pos2, particleId);
+
+        RESTORE_MAP_PARTICLEENTRY(save);
+
+        return ret;
+    }
+
+    byte *__cdecl FUN_0050b510_CCA(Vec3f *pos, int particleId) 
+    {
+        return FUN_0050b510_WithMap(pos, particleId, (int)MapType::CCA);
+    }
+
+    byte *__cdecl FUN_0050b510_Seabed(Vec3f *pos, int particleId) 
+    {
+        return FUN_0050b510_WithMap(pos, particleId, (int)MapType::Seabed_Upper);
+    }
+
+    byte *__cdecl FUN_00509dc4_CCA(Vec3f *pos, Vec3f *pos2, int particleId, uint16_t flags)
+    {
+        return FUN_00509dc4_WithMap(pos, pos2, particleId, flags, (int)MapType::CCA);
+    }
+
+    byte *__cdecl FUN_00509590_Seabed(Vec3f *pos, int particleId)
+    {
+        return FUN_00509590_WithMap(pos, particleId, (int)MapType::Seabed_Upper);
+    }
+
+    byte *__cdecl FUN_00509590_Tower(Vec3f *pos, int particleId)
+    {
+        return FUN_00509590_WithMap(pos, particleId, (int)MapType::Tower);
+    }
+
+    byte *__cdecl FUN_00509590_Wilds(Vec3f *pos, int particleId)
+    {
+        return FUN_00509590_WithMap(pos, particleId, (int)MapType::Wilds1);
+    }
+
+    byte *__cdecl FUN_00509590_Seabed0x20f_Tower0x223(Vec3f *pos, int particleId)
+    {
+        if (particleId == 0x20f)
+            return FUN_00509590_WithMap(pos, particleId, (int)MapType::Seabed_Upper);
+        else if (particleId == 0x223)
+            return FUN_00509590_WithMap(pos, particleId, (int)MapType::Tower);
+
+        // Particle 0x12f, doesn't matter which map.
+        return FUN_00509590_WithMap(pos, particleId, (int)MapType::Tower);
+    }
+
+    byte *__cdecl FUN_0050a664_Seabed(Vec3f *pos, Vec3f *pos2, int particleId, int param4, uint16_t flags)
+    {
+        return FUN_0050a664_WithMap(pos, pos2, particleId, param4, flags, (int)MapType::Seabed_Upper);
+    }
+
+    byte *__cdecl FUN_0050a664_Wilds(Vec3f *pos, Vec3f *pos2, int particleId, int param4, uint16_t flags)
+    {
+        return FUN_0050a664_WithMap(pos, pos2, particleId, param4, flags, (int)MapType::Wilds1);
+    }
+
+    byte *__cdecl FUN_0050b510_Wilds(Vec3f *pos, int particleId) 
+    {
+        return FUN_0050b510_WithMap(pos, particleId, (int)MapType::Wilds1);
+    }
+
+    byte *__cdecl FUN_00509dc4_Seabed(Vec3f *pos, Vec3f *pos2, int particleId, uint16_t flags)
+    {
+        return FUN_00509dc4_WithMap(pos, pos2, particleId, flags, (int)MapType::Seabed_Upper);
+    }
+
+    byte *__cdecl FUN_0050bab4_Tower(Vec3f *pos1, Vec3f *pos2, int particleId)
+    {
+        return FUN_0050bab4_WithMap(pos1, pos2, particleId, (int)MapType::Tower);
+    }
+
+    byte *__cdecl FUN_00509b24_Tower(Vec3f *pos1, Vec3f *pos2, int particleId)
+    {
+        return FUN_00509b24_WithMap(pos1, pos2, particleId, (int)MapType::Tower);
+    }
+
+    void PatchCCAMonsterParticles()
+    {
+        // Mericarol/Merikle/Mericus spit
+        PatchCALL(0x573fc8, 0x573fcd, (int)FUN_00509dc4_CCA);
+        PatchCALL(0x573f7d, 0x573f82, (int)FUN_00509dc4_CCA);
+        // Mericarol/Merikle/Mericus Megid Cloud and spores
+        PatchCALL(0x5768c5, 0x5768ca, (int)FUN_0050b510_CCA);
+        PatchCALL(0x5768f6, 0x5768fb, (int)FUN_0050b510_CCA);
+        // Gi Gue bomb 'muzzle' effect on Gi Gue
+        PatchCALL(0x56a85f, 0x56a864, (int)FUN_0050b510_CCA);
+        // Gi Gue confuse ball attack
+        PatchCALL(0x56ce67, 0x56ce6c, (int)FUN_00509dc4_CCA);
+        PatchCALL(0x56ce84, 0x56ce84, (int)FUN_00509dc4_CCA);
+        // Gi Gue death particles
+        PatchCALL(0x56b1fb, 0x56b200, (int)FUN_0050b510_CCA);
+        PatchCALL(0x56b20a, 0x56b20f, (int)FUN_0050b510_CCA);
+    }
+
+    void PatchSeabedMonsterParticles()
+    {
+        // Dolmdarl snare particles
+        PatchCALL(0x552f2f, 0x552f34, (int)FUN_0050b510_Seabed);
+        // Recon floating particle
+        PatchCALL(0x58a5b7, 0x58a5bc, (int)FUN_00509590_Seabed);
+        // Delbiter roar
+        PatchCALL(0x54bc4e, 0x54bc53, (int)FUN_00509590_Seabed);
+        // Delbiter shock/megid particles from roar
+        PatchCALL(0x54b0f0, 0x54b0f5, (int)FUN_0050b510_Seabed);
+        PatchCALL(0x54b0ff, 0x54b104, (int)FUN_0050b510_Seabed);
+        PatchCALL(0x54b028, 0x54b02d, (int)FUN_0050b510_Seabed);
+        PatchCALL(0x54b037, 0x54b03c, (int)FUN_0050b510_Seabed);
+        // Delbiter laser related
+        PatchCALL(0x54e073, 0x54e078, (int)FUN_0050a664_Seabed);
+        PatchCALL(0x54b6c1, 0x54b6c6, (int)FUN_0050b510_Seabed);
+        // Delbiter particle that follows after a roar
+        PatchCALL(0x54aa26, 0x54aa2b, (int)FUN_00509590_Seabed);
+        PatchCALL(0x54a9ec, 0x54a9f1, (int)FUN_00509590_Seabed);
+        PatchCALL(0x54a9cd, 0x54a9d2, (int)FUN_00509590_Seabed);
+        // Morfos laser
+        PatchCALL(0x57ba35, 0x57ba3a, (int)FUN_0050b510_Seabed);
+        PatchCALL(0x57d1dd, 0x57d1e2, (int)FUN_00509dc4_Seabed);
+        // Morfos shield particles
+        PatchCALL(0x57a041, 0x57a046, (int)FUN_0050b510_Seabed);
+        PatchCALL(0x57a04c, 0x57a051, (int)FUN_0050b510_Seabed);
+        // Morfos spinning laser particle
+        PatchCALL(0x57aeb5, 0x57aeba, (int)FUN_0050b510_Seabed);
+    }
+
+    void PatchTowerMonsterParticles()
+    {
+        // Ill Gill - Charge particles
+        PatchCALL(0x52fb3d, 0x52fb42, (int)FUN_00509590_Tower);
+        PatchCALL(0x52fb1b, 0x52fb20, (int)FUN_00509590_Tower);
+        // Ill Gill - Snare/root particles from the Ill Gill
+        PatchCALL(0x52f035, 0x52f03a, (int)FUN_00509b24_Tower);
+        PatchCALL(0x52ef94, 0x52ef99, (int)FUN_0050bab4_Tower);
+        // Epsilon - epsigard shield particle
+        PatchCALL(0x55b77d, 0x55b782, (int)FUN_00509590_Tower);
+        // Epsilon - epsigard closing particles
+        PatchCALL(0x55926f, 0x559274, (int)FUN_00509590_Tower);
+        PatchCALL(0x558fa4, 0x558fa9, (int)FUN_00509590_Tower);
+    }
+
+    void PatchWildsMonsterParticles()
+    {
+        // Dorphon also shares some particles with Delbiter
+        // Dorphon - I forget what these are.
+        PatchCALL(0x5a6b8a, 0x5a6b8f, (int)FUN_00509590_Wilds);
+        PatchCALL(0x5a6b68, 0x5a6b6d, (int)FUN_00509590_Wilds);
+        PatchCALL(0x5a6b49, 0x5a6b4e, (int)FUN_00509590_Wilds);
+        // Dorphon - Laser attack particles
+        PatchCALL(0x54e073, 0x54e078, (int)FUN_0050a664_Wilds);
+        PatchCALL(0x5a77b7, 0x5a77bc, (int)FUN_0050b510_Wilds);
+        // Dorphon - "Vacuum" effect after being stunned
+        PatchCALL(0x5a7ed9, 0x5a7ede, (int)FUN_00509590_Wilds);
+    }
+
+
+    void PatchMonsterParticlesSharedAreas()
+    {
+        // Dolmdarl and Ill Gill share this call for particle
+        // rendered at their snared/rooted target.
+        PatchCALL(0x579031, 0x579036, (int)FUN_00509590_Seabed0x20f_Tower0x223);
+    }
+
+    void PatchOmnispawnParticles()
+    {
+        // Wrap loading of particleentry.dat to load all map particles on first call.
+        *(uint32_t *)0x9f8558 = (uint32_t)WrapLoadParticleEntry;
+
+        PatchCCAMonsterParticles();
+        PatchSeabedMonsterParticles();
+        PatchTowerMonsterParticles();
+        PatchWildsMonsterParticles();
+        PatchMonsterParticlesSharedAreas();
+    }
+
+}

--- a/Blue Burst Patch Project/omnispawn_particles.cpp
+++ b/Blue Burst Patch Project/omnispawn_particles.cpp
@@ -1,3 +1,5 @@
+#ifdef PATCH_OMNISPAWN
+
 #include "helpers.h"
 #include "omnispawn.h"
 #include <mathutil.h>
@@ -334,3 +336,5 @@ namespace Omnispawn
     }
 
 }
+
+#endif

--- a/Blue Burst Patch Project/omnispawn_sound_effects.cpp
+++ b/Blue Burst Patch Project/omnispawn_sound_effects.cpp
@@ -1,0 +1,167 @@
+#include "helpers.h"
+#include "omnispawn.h"
+#include <mathutil.h>
+#include "map.h"
+
+// TODO: Cleanup this file.
+
+namespace Omnispawn
+{
+    using Map::MapType;
+
+    typedef uint32_t (__cdecl *LoadMapSoundDataFunction)(uint32_t);
+    LoadMapSoundDataFunction LoadMapSoundData = reinterpret_cast<LoadMapSoundDataFunction>(0x00828d40);
+
+    /// Loads all map-specific .pac files
+    void __cdecl LoadSoundDataAllMaps()
+    {
+        for (uint32_t i = 0; i <= (uint32_t) MapType::MAX_INDEX; i++)
+        {
+            if (LoadMapSoundData(i) == 0)
+            {
+                return;
+            }
+        }
+
+        return;
+    }
+
+    /// Returns 3 to fix the missing dark enemy spawn sound effect in CCA.
+    uint32_t __cdecl HandleSfxDarkSpawn(void)
+    {
+        return 3;
+    }
+
+    /// Returns map number for Wilds1 to fix sound effects for Wilds/Crater enemies.
+    int __cdecl GetWildsMapNumber()
+    {
+        return (int)MapType::Wilds1;
+    }
+
+    /// Returns map number for Sub Desert 1 to fix sound effects for Desert enemies.
+    int __cdecl GetDesertMapNumber()
+    {
+        return (int)MapType::Desert1;
+    }
+
+    void PatchSoundEffectMapReferences()
+    {
+        PatchCALL(0x578a6f, 0x578a74, (int)&HandleSfxDarkSpawn);
+
+        uint32_t addrsGetMapCrater[] =
+        {
+            0x5a592b, // Boota family - War cry
+            0x5a5957, // Boota family - Arm attack
+            0x5a56ff, // Boota family - Ze Boota rush attack
+            0x5a5983, // Boota family - Flinched
+            0x5a59af, // Boota family - Death sound
+
+            0x5b1417, // Lizard family - Spawn sound 1
+            0x5b144d, // Lizard family - Spawn sound 2
+            0x5aff07, // Lizard family - Movement
+            0x5b0104, // Lizard family - Attack step 1
+            0x5aff74, // Lizard family - Attack step 2
+            0x5aefbe, // Lizard family - Death sound
+            0x5af2c1, // Lizard family - unknown
+            0x5af701, // Lizard family - unknown
+            0x5af783, // Lizard family - unknown
+
+            0x5a3875, // Astark - Spawn landing
+            0x5a2cb8, // Astark - Punch attack
+            0x5a2884, // Astark - Breath/particle attack
+            0x5a3276, // Astark - Moving
+            0x5a254c, // Astark - Jump attack initiated
+            0x5a23d3, // Astark - Jump attack landing
+            0x5a2133, // Astark - Flinch
+            0x5a1fa6, // Astark - Death sound 1
+            0x5a2035, // Astark - Death sound 2
+            0x5a2f5a, // Astark - Taunt?
+            0x5a343b, // Astark - Another spawn landing?
+
+            0x5b46d2, // Zu family - Wing flap
+            0x5b2c25, // Zu family - Dive attack
+            0x5b332d, // Zu family - Laser attack
+            0x5b4132, // Zu family - Dead (start fall)
+            0x5b40ad, // Zu family - Dead (hit ground)
+            0x5b43ec, // Zu family - unknown
+
+            0x5a9655, // Dorphon - Spawn
+            0x5a953d, // Dorphon - Spawn 2
+            0x5a8b1d, // Dorphon - Spawn 3
+            0x5a7b39, // Dorphon - Laser
+            0x5a7dd7, // Dorphon - Some roar
+            0x5a7fdd, // Dorphon - Stomp/punch
+            0x5a7fa9, // Dorphon - Right punch?
+            0x5a8847, // Dorphon - Charge windup
+            0x5a85e2, // Dorphon - Charge start
+            0x5a865a, // Dorphon - Charge stop
+            0x5a8fdd, // Dorphon - Turning sound
+            0x5a745d, // Dorphon - Death
+            0x5a7337, // Dorphon - Death 2
+        };
+        for (auto addr : addrsGetMapCrater)
+        {
+            PatchCALL(addr, addr + 5, (int)&GetWildsMapNumber);
+        }
+
+        // Goran family
+        uint32_t adrrsGetMapDesert[] = {
+            0x5ad62f, // Goran family - War cry 1
+            0x5ad609, // Goran family - War cry 2
+            0x5ad663, // Goran family - Attack
+            0x5ad697, // Goran family - Hit by attack
+            0x5ad6cb, // Goran family - Dead
+            0x5ad5ce, // Goran family - Dead 2
+
+            0x5b51b3, // Merissa family - Spawn
+            0x5b562f, // Merissa family - Hop 1
+            0x5b5666, // Merissa family - Hop 2
+            0x5b6540, // Merissa family - Jump attack start
+            0x5b6632, // Merissa family - Jump attack landing
+            0x5b5f53, // Merissa family - Jump over player
+            0x5b5f8a, // Merissa family - Land behind player
+            0x5b6391, // Merissa family - Stab attack
+            0x5b6465, // Merissa family - Faster stab attack
+            0x5b5263, // Merissa family - Hit by attack
+            0x5b53a5, // Merissa family - Dead 1
+            0x5b53be, // Merissa family - Dead 2
+
+            0x5aa719, // Girtablulu - Turn 1?
+            0x5aa6cc, // Girtablulu - Melee 1
+            0x5ab01b, // Girtablulu - Melee 2
+            0x5aa4a5, // Girtablulu - Hit by attack
+            0x5aa5d2, // Girtablulu - Center hit by attack
+            0x5aa4d3, // Girtablulu - Unknown
+            0x5aa3d8, // Girtablulu - Unknown
+        };
+        for (auto addr : adrrsGetMapDesert)
+        {
+            PatchCALL(addr, addr + 5, (int)&GetDesertMapNumber);
+        }
+    }
+
+
+    void PatchOmnispawnSoundEffects()
+    {
+        // This is an initlist that loads assets that should stay loaded 
+        // for the entire lifetime of the program
+        InitList& lst = InitList::GetInitList(0x009ff6e0, 0x009ff7c0);
+        // No uninit function because at that point the game is exiting anyway
+        lst.AddFunctionPair(InitList::FunctionPair(LoadSoundDataAllMaps, nullptr));
+        lst.AddListReferenceAddress({0x007a666d + 1, 0x007a63a7 + 1});
+        lst.AddSizeReferenceAddress({0x007a63a2 + 1, 0x007a6668 + 1});
+
+        // Stub out load_map_sound_data_:00815584
+        // Because verything should already be loaded
+        StubOutFunction(0x00815584, 0x0081558f);
+
+        // Stub out unload_map_sound_data:00828c38
+        // Because we wan't to keep everything loaded permanently
+        StubOutFunction(0x00828c38, 0x00828d24);
+
+        // And fix enemies that look up sound effect ID based on the current map.
+        // Because all map sound effect files are loaded, this simply returns a map
+        // number where they already exist.
+        PatchSoundEffectMapReferences();
+    }
+}

--- a/Blue Burst Patch Project/omnispawn_sound_effects.cpp
+++ b/Blue Burst Patch Project/omnispawn_sound_effects.cpp
@@ -1,3 +1,5 @@
+#ifdef PATCH_OMNISPAWN
+
 #include "helpers.h"
 #include "omnispawn.h"
 #include <mathutil.h>
@@ -165,3 +167,5 @@ namespace Omnispawn
         PatchSoundEffectMapReferences();
     }
 }
+
+#endif

--- a/Blue Burst Patch Project/psobb.cpp
+++ b/Blue Burst Patch Project/psobb.cpp
@@ -3,6 +3,10 @@
 #include "globals.h"
 
 // These should be specified in the project's preprocessor macros to enable.
+// In Visual Studio, right click the project in the Solution Explorer and select Properties.
+// Prepend or append them to "Preprocessor Definitions" which can be found under
+// Configuration Properties > C/C++ > Preprocessor.
+//
 // Alternatively in the future, maybe they could go into pch.h or a file included there.
 // Leaving here for documentation.
 #if 0
@@ -14,12 +18,14 @@
 #define PATCH_CUSTOMIZE_MENU
 #define PATCH_FASTWARP
 #define PATCH_OMNISPAWN
-#define PATCH_NEWENEMY
+#define PATCH_NEWENEMY // This is missing a header?
 #define PATCH_LARGE_ASSETS
 #define PATCH_OMNISPAWN
 #define PATCH_ENEMY_CONSTRUCTOR_LISTS
 #define PATCH_EDITORS
 #define PATCH_INITLISTS
+#define PATCH_MAP_OBJECT_CONSTRUCTOR_LISTS
+#define PATCH_HOOKS
 #endif
 
 #ifdef PATCH_IME
@@ -162,4 +168,8 @@ void PSOBB()
     // Should be last so that other patches can apply their changes first
     InitList::PatchAllInitLists();
 #endif
+
+    // Increase ax size of decompress buffer for ItemMagEdit
+    *(uint32_t *)0x5dba7c = 0x2000; 
 }
+

--- a/Blue Burst Patch Project/psobb_functions.cpp
+++ b/Blue Burst Patch Project/psobb_functions.cpp
@@ -12,3 +12,11 @@ void(__stdcall *pf_opcode_hud_show)() = (void(__stdcall *)())0x6b3770;
 void(__cdecl *pf_nop)() = (void(__cdecl *)())0x61cdb0;
 void *(__cdecl *pf_malloc)(size_t) = (void *(__cdecl *)(size_t))0x859c55;
 void(__cdecl *pf_free)(void *) = (void(__cdecl *)(void *))0x858882;
+
+int(__cdecl *was_key_pressed)(unsigned char) = (int(__cdecl *)(unsigned char))0x7bfff8;
+int(__fastcall *is_ctrl_pressed)(void *) = (int(__fastcall *)(void *))0x78f484;
+int(__fastcall *is_alt_pressed)() = (int(__fastcall *)())0x7c00d0;
+int(__cdecl *is_pso_keycode_pressed_with_only_alt)(uint8_t) = (int(__cdecl *)(uint8_t))0x7c0044;
+int(__fastcall *is_key_pressed)(unsigned char) = (int(__fastcall *)(unsigned char))0x7bfce4;
+int(__cdecl *is_mouse_button_pressed)(unsigned int) = (int(__cdecl *)(unsigned int))0x7c00e8;
+int(__cdecl *was_mouse_button_pressed)(unsigned int) = (int(__cdecl *)(unsigned int))0x7c0108;

--- a/Blue Burst Patch Project/psobb_functions.h
+++ b/Blue Burst Patch Project/psobb_functions.h
@@ -13,3 +13,12 @@ extern void(__stdcall *pf_opcode_hud_show)();
 extern void(__cdecl *pf_nop)();
 extern void *(__cdecl *pf_malloc)(size_t);
 extern void(__cdecl *pf_free)(void *);
+
+
+extern int(__cdecl *was_key_pressed)(unsigned char);
+extern int(__fastcall *is_ctrl_pressed)(void *);
+extern int(__fastcall *is_alt_pressed)();
+extern int(__cdecl *is_pso_keycode_pressed_with_only_alt)(uint8_t);
+extern int(__fastcall *is_key_pressed)(unsigned char);
+extern int(__cdecl *is_mouse_button_pressed)(unsigned int);
+extern int(__cdecl *was_mouse_button_pressed)(unsigned int);


### PR DESCRIPTION
Patches essentially load all particles at startup and wrap certain 'create particle' calls to temporarily swap out the current map's particle list with the one expected for the monster. The map specific particles for an area are still reloaded when entering that area.

The sound effect patches replace calls to 'get current map' to returning a map ID where the monster exists.